### PR TITLE
評価関数の重みベクトルの読み込みを別のスレッドで行うように変更

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,8 +37,7 @@ int main(int argc, char* argv[]) {
 	Position::initZobrist();
 	auto s = std::unique_ptr<Searcher>(new Searcher);
 	s->init();
-	// 一時オブジェクトの生成と破棄
-	std::unique_ptr<Evaluater>(new Evaluater)->init(s->options["Eval_Dir"], true);
+	
 	s->doUSICommandLoop(argc, argv);
 	s->threads.exit();
 }


### PR DESCRIPTION
評価関数の重みベクトルの読み込みを別のスレッドで行うように変更しました。
これで将棋所等でエンジンとして登録する際にタイムアウトしなくなるはずです。
