### PR TITLE
定跡で指した際に評価値が「mate 1」にならないように修正

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1392,7 +1392,7 @@ void MainThread::search() {
                      << " score " << scoreToUSI(std::get<1>(bookMoveScore))
                      << " pv " << std::get<0>(bookMoveScore).toUSI()
                      << SYNCENDL;
-
+            rootMoves[0].score = std::get<1>(bookMoveScore);
             goto finalize;
         }
     }


### PR DESCRIPTION
定跡で指した際に評価値が一律「mate 1」になってしまうようでしたので修正してみました。
MainThread::search()で
　・定跡にヒットした際にrootMoves[0].scoreに値を入れておく
　・定跡にヒットした場合はfinalize:以降のpvInfoToUSI()の部分をスキップする
のいずれかで修正可能かと思いましたが、前者にしてみました。