### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,17 @@
+name: Make CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make publish
+      run: cd src && make publish


### PR DESCRIPTION
https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/

Perhaps this does not matter since https://github.com/HiraokaTakuya/apery_rust is more active. :-)